### PR TITLE
Add Release Drafter automation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,48 @@
+name-template: 'DraCuLa StreamNZB Template $RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+
+categories:
+  - title: 'Profiles and scoring'
+    labels:
+      - 'profiles'
+  - title: 'Formatter'
+    labels:
+      - 'formatter'
+  - title: 'Vidhin and Define Library'
+    labels:
+      - 'vidhin'
+  - title: 'Validation and tests'
+    labels:
+      - 'tests'
+  - title: 'Documentation'
+    labels:
+      - 'docs'
+  - title: 'Automation and maintenance'
+    labels:
+      - 'automation'
+      - 'github-actions'
+
+exclude-labels:
+  - 'skip-changelog'
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,29 @@
+name: Update draft release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - closed
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update_release_draft:
+    name: Update draft release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update release draft
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds Release Drafter so merged PRs continuously populate a draft GitHub release.

The draft groups changes using the repository's automatic labels: profiles/scoring, formatter, Vidhin/Define Library, tests, docs, and automation/maintenance. Version resolution supports `major`, `minor`, and `patch` labels, defaulting to patch when no release-level label is present.

The workflow updates on pushes to `main`, relevant pull-request metadata changes, and manual dispatch. It does not publish releases automatically.