### PR TITLE
ci: enforce pull request metadata conventions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+Describe what changed and why.
+
+## Validation
+
+Describe the checks you ran or the expected CI coverage.
+
+## Release impact
+
+Apply one release-impact label when appropriate:
+
+- `patch` — backward-compatible fix or maintenance change
+- `minor` — backward-compatible feature or meaningful behavior change
+- `major` — breaking change
+- `skip-changelog` — internal-only change that should not appear in release notes
+
+If no `major`, `minor`, or `patch` label is applied, Release Drafter defaults to a patch release.
+
+## Repository conventions
+
+- Branch: `type/short-description`
+- PR title: `type: concise description`
+- Allowed types: `feat`, `fix`, `chore`, `docs`, `test`, `ci`, `refactor`, `perf`

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -32,6 +32,10 @@ jobs:
             [docs]="0075ca|Documentation changes"
             [automation]="6f42c1|Repository automation changes"
             [github-actions]="1d76db|GitHub Actions dependency and workflow changes"
+            [major]="b60205|Breaking release change"
+            [minor]="0e8a16|Backward-compatible feature or behavior change"
+            [patch]="5319e7|Backward-compatible fix or maintenance change"
+            [skip-changelog]="cfd3d7|Exclude this PR from generated release notes"
           )
 
           for name in "${!labels[@]}"; do

--- a/.github/workflows/validate-pr-metadata.yml
+++ b/.github/workflows/validate-pr-metadata.yml
@@ -1,0 +1,50 @@
+name: Validate pull request metadata
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate PR title, body, and branch
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate metadata conventions
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          title_re='^(feat|fix|chore|docs|test|ci|refactor|perf): .+'
+          branch_re='^(feat|fix|chore|docs|test|ci|refactor|perf|automation)/[a-z0-9][a-z0-9-]*$'
+
+          if [[ ! "$PR_TITLE" =~ $title_re ]]; then
+            echo "ERROR: PR title must match 'type: concise description'." >&2
+            echo "Allowed types: feat, fix, chore, docs, test, ci, refactor, perf." >&2
+            exit 1
+          fi
+
+          if [[ ! "$PR_BRANCH" =~ $branch_re ]]; then
+            echo "ERROR: branch must match 'type/short-description'." >&2
+            echo "Allowed prefixes: feat, fix, chore, docs, test, ci, refactor, perf, automation." >&2
+            exit 1
+          fi
+
+          body="${PR_BODY:-}"
+          body="$(printf '%s' "$body" | tr -d '[:space:]')"
+          if [[ -z "$body" ]]; then
+            echo "ERROR: PR description must not be empty." >&2
+            exit 1
+          fi


### PR DESCRIPTION
Adds release-impact labels and a lightweight PR metadata quality gate.

Changes:
- Extends the managed label set with `major`, `minor`, `patch`, and `skip-changelog` for Release Drafter versioning and changelog control.
- Adds a pull request template documenting summary, validation, release-impact labels, branch naming, and PR title conventions.
- Adds a PR metadata validation workflow requiring conventional PR titles, `type/short-description` branches, and a non-empty PR body.
- Exempts Dependabot so automated GitHub Actions update PRs continue to flow through validation and auto-merge unchanged.

This does not automatically assign release-impact labels; those remain an explicit choice based on the semantic impact of each PR.