### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/audit-actions-security.yml
+++ b/.github/workflows/audit-actions-security.yml
@@ -1,0 +1,37 @@
+name: Audit GitHub Actions security
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/check_workflow_security.py'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/check_workflow_security.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actions-security-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Audit workflow security
+        run: python scripts/check_workflow_security.py

--- a/.github/workflows/check-streamnzb-upstream.yml
+++ b/.github/workflows/check-streamnzb-upstream.yml
@@ -55,6 +55,14 @@ jobs:
           set -o pipefail
           ./scripts/test_streamnzb_compat.sh 2>&1 | tee streamnzb-upstream-compat.log
 
+      - name: Upload compatibility diagnostics
+        if: steps.compat.outcome == 'failure'
+        uses: actions/upload-artifact@v6
+        with:
+          name: streamnzb-upstream-compat-${{ steps.upstream.outputs.tag }}
+          path: streamnzb-upstream-compat.log
+          retention-days: 14
+
       - name: Open or update compatibility issue
         if: steps.compat.outcome == 'failure'
         env:

--- a/.github/workflows/sync-vidhin.yml
+++ b/.github/workflows/sync-vidhin.yml
@@ -27,10 +27,14 @@ jobs:
           python-version: "3.13"
 
       - name: Test generator against accepted baseline
-        run: python tests/test_vidhin_sync.py
+        run: |
+          set -o pipefail
+          python tests/test_vidhin_sync.py 2>&1 | tee vidhin-sync.log
 
       - name: Track mapped Vidhin rules
-        run: python scripts/sync_vidhin.py
+        run: |
+          set -o pipefail
+          python scripts/sync_vidhin.py 2>&1 | tee -a vidhin-sync.log
 
       - name: Ignore metadata-only sync changes
         run: |
@@ -109,3 +113,16 @@ jobs:
           labels: |
             automation
             streamnzb
+
+      - name: Upload Vidhin sync diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: vidhin-sync-diagnostics-${{ github.run_id }}
+          path: |
+            vidhin-sync.log
+            generated/vidhin-sync-report.md
+            generated/vidhin-defines.json
+            generated/streamnzb-defines.txt
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: validate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Validate profile and Define library

--- a/scripts/check_workflow_security.py
+++ b/scripts/check_workflow_security.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import re
+import sys
+
+WORKFLOWS = Path('.github/workflows')
+PRIVILEGED_TRIGGERS = ('pull_request_target:', 'workflow_run:')
+
+
+def audit(path: Path) -> list[str]:
+    text = path.read_text(encoding='utf-8')
+    errors: list[str] = []
+
+    if not re.search(r'^permissions:\s*(?:$|\n)', text, flags=re.MULTILINE):
+        errors.append('missing explicit top-level permissions block')
+
+    if re.search(r'^permissions:\s*write-all\s*$', text, flags=re.MULTILINE):
+        errors.append('uses permissions: write-all')
+
+    privileged = any(
+        re.search(rf'^\s{{2}}{re.escape(trigger)}\s*$', text, flags=re.MULTILINE)
+        for trigger in PRIVILEGED_TRIGGERS
+    )
+    checks_out = bool(re.search(r'uses:\s*actions/checkout@', text))
+    if privileged and checks_out:
+        errors.append(
+            'privileged pull_request_target/workflow_run workflow checks out repository code'
+        )
+
+    if re.search(r'\bsecrets:\s*inherit\b', text):
+        errors.append('uses secrets: inherit')
+
+    return errors
+
+
+def main() -> int:
+    failures: list[tuple[Path, str]] = []
+    for path in sorted(WORKFLOWS.glob('*.y*ml')):
+        for error in audit(path):
+            failures.append((path, error))
+
+    if failures:
+        print('Workflow security audit failed:', file=sys.stderr)
+        for path, error in failures:
+            print(f'  {path}: {error}', file=sys.stderr)
+        return 1
+
+    print('Workflow security audit passed.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/check_workflow_security.py
+++ b/scripts/check_workflow_security.py
@@ -6,6 +6,7 @@ import sys
 
 WORKFLOWS = Path('.github/workflows')
 PRIVILEGED_TRIGGERS = ('pull_request_target:', 'workflow_run:')
+FLOATING_ACTION_REFS = {'main', 'master', 'latest', 'develop', 'development'}
 
 
 def audit(path: Path) -> list[str]:
@@ -30,6 +31,17 @@ def audit(path: Path) -> list[str]:
 
     if re.search(r'\bsecrets:\s*inherit\b', text):
         errors.append('uses secrets: inherit')
+
+    for match in re.finditer(r'^\s*-?\s*uses:\s*([^\s#]+)', text, flags=re.MULTILINE):
+        action = match.group(1)
+        if action.startswith('./') or action.startswith('docker://'):
+            continue
+        if '@' not in action:
+            errors.append(f'action reference is not versioned: {action}')
+            continue
+        _, ref = action.rsplit('@', 1)
+        if ref.lower() in FLOATING_ACTION_REFS:
+            errors.append(f'action uses floating ref @{ref}: {action}')
 
     return errors
 


### PR DESCRIPTION
## Summary

Hardens the repository's GitHub Actions setup without changing the functional release or validation flow.

## Changes

- Add a workflow-security audit for explicit permissions, privileged-trigger checkout risks, inherited secrets, unversioned actions, and floating action refs such as `@main`/`@master`.
- Add PR/ref concurrency to `Validate StreamNZB Template` so obsolete validation runs are cancelled when newer commits arrive.
- Preserve full latest-StreamNZB compatibility logs as private GitHub Actions artifacts for 14 days when the scheduled compatibility check fails.
- Preserve Vidhin sync diagnostics and generated outputs as private GitHub Actions artifacts for 14 days when the scheduled sync fails.

## Validation

Existing repository validation should run normally. The new Actions security audit also runs because this PR changes workflow files.

## Release impact

Internal CI/repository hardening only. Recommended label: `skip-changelog`.