### PR TITLE
ci: configure CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: "en-US"
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "github-actions[bot]"
+
+  path_filters:
+    - "!generated/**"
+    - "!formatter.txt"
+    - "!formatter-debug.txt"
+    - "!.streamnzb-compat/**"
+
+  path_instructions:
+    - path: ".github/workflows/**"
+      instructions: |
+        Focus on GitHub Actions correctness and security. Check event trust boundaries,
+        token permissions, secret exposure, privileged triggers, concurrency behavior,
+        shell quoting, and whether automation can unintentionally modify main or publish
+        releases. Do not suggest making advisory maintenance checks block normal PR CI.
+
+    - path: "scripts/**/*.py"
+      instructions: |
+        Focus on correctness, deterministic output, error handling, compatibility with
+        repository automation, and regressions affecting StreamNZB profiles, formatter,
+        Vidhin synchronization, or Discord payload generation.
+
+    - path: "tests/**/*.py"
+      instructions: |
+        Check that tests cover meaningful behavior and failure modes rather than merely
+        mirroring implementation details. Flag gaps that could allow profile, Define,
+        formatter, Vidhin, or automation regressions through CI.
+
+    - path: "**/*.sh"
+      instructions: |
+        Review shell code for safe quoting, exit-code propagation, pipe failures,
+        temporary-file handling, deterministic CI behavior, and accidental secret or
+        credential exposure.
+
+    - path: "tests/streamnzb_compat/**/*.go"
+      instructions: |
+        Focus on StreamNZB compatibility semantics, regression coverage, deterministic
+        tests, and whether changes could create false compatibility passes or failures.


### PR DESCRIPTION
## Summary

Add repository-local CodeRabbit configuration for focused advisory PR reviews.

## Changes

- Enable automatic CodeRabbit review for non-draft PRs.
- Keep CodeRabbit advisory by disabling the request-changes workflow.
- Skip Dependabot and GitHub Actions bot PRs so dependency maintenance remains quiet and automatic.
- Exclude generated StreamNZB artifacts and published formatter outputs from review noise.
- Add focused review instructions for GitHub Actions, Python, shell, tests, and the Go StreamNZB compatibility harness.
- Disable nonessential poem output while retaining high-level PR summaries and review status.

## Validation

The repository's normal validation and PR metadata workflows should run. CodeRabbit should also detect this branch-local `.coderabbit.yaml` and review this PR using the new configuration.

## Release impact

Internal review tooling only. Recommended label: `skip-changelog`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code review configuration with English-language settings.
  * Configured review guidance for GitHub Actions, Python, shell scripts, tests, and compatibility checks.
  * Added path exclusions to streamline automated reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->