### PR TITLE
ci: run Vidhin sync on Saturday

### DIFF
--- a/.github/workflows/sync-vidhin.yml
+++ b/.github/workflows/sync-vidhin.yml
@@ -2,7 +2,7 @@ name: Sync Vidhin release groups
 
 on:
   schedule:
-    - cron: "0 6 * * 1"
+    - cron: "0 6 * * 6"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Change the scheduled Vidhin release-group sync from Monday to Saturday.

## Changes

- Update the Vidhin sync cron from `0 6 * * 1` to `0 6 * * 6`.
- Keep the run time at 06:00 UTC.
- Leave the existing manual trigger, permissions, concurrency, diagnostics, and PR-generation behavior unchanged.

## Validation

The repository's normal PR metadata and StreamNZB validation workflows should run against this one-line schedule change.

## Release impact

Internal automation schedule change only. Recommended label: `skip-changelog`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The scheduled Vidhin synchronization now runs weekly on Saturdays instead of Mondays.
  * Manual synchronization remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->